### PR TITLE
Fix hopper item duplication (#2052)

### DIFF
--- a/src/pocketmine/tile/Hopper.php
+++ b/src/pocketmine/tile/Hopper.php
@@ -99,7 +99,7 @@ class Hopper extends Spawnable implements InventoryHolder, Container, Nameable{
 		$area = clone $this->getBlock()->getBoundingBox(); //Area above hopper to draw items from
 		$area->maxY = ceil($area->maxY) + 1; //Account for full block above, not just 1 + 5/8
 		foreach($this->getLevel()->getChunkEntities($this->getBlock()->x >> 4, $this->getBlock()->z >> 4) as $entity){
-			if(!($entity instanceof DroppedItem)){
+			if(!($entity instanceof DroppedItem) or !$entity->isAlive()){
 				continue;
 			}
 			if(!$entity->boundingBox->intersectsWith($area)){


### PR DESCRIPTION
### Description
<!-- What's this PR for? -->


### Reason to modify
<!-- 
- Think twice before modifying: is it the best way? will it break things? 
- Have you made sure that there is actually a problem before trying to fix it?
- Explain the logic behind your changes - WHY and HOW what you have done works
-->

### Tests & Reviews
<!-- Uncomment based on the situation -->

<!-- I have tested the code and it works. -->

<!-- Please review things below: -->

This prevents items being pulled/sucked into multiple hoppers on the same tick.